### PR TITLE
Allow client to disable logging to SSH session

### DIFF
--- a/sshsrv/ssh.go
+++ b/sshsrv/ssh.go
@@ -519,13 +519,15 @@ func (s *sshServer) handleConnection(nConn net.Conn) {
 				switch line {
 				case "logs":
 					loggingEnabled = true
+					term.Write([]byte("Logging enabled\n"))
 				case "nologs":
 					loggingEnabled = false
+					term.Write([]byte("Logging disabled\n"))
 				case "urls":
 					if len(receivedURLs) > 0 {
 						term.Write([]byte(fmt.Sprintf("%s\n", receivedURLs)))
 					} else {
-						term.Write([]byte(fmt.Sprintf("No urls received yet\n")))
+						term.Write([]byte("No urls received yet\n"))
 					}
 				case "quit":
 					return

--- a/sshsrv/ssh.go
+++ b/sshsrv/ssh.go
@@ -474,6 +474,7 @@ func (s *sshServer) handleConnection(nConn net.Conn) {
 			defer channel.Close()
 			defer conn.Close()
 			loggingEnabled := true
+			receivedURLs := []byte{}
 			go func() {
 				defer channel.Close()
 				defer conn.Close()
@@ -490,6 +491,7 @@ func (s *sshServer) handleConnection(nConn net.Conn) {
 							if err != nil {
 								log.Printf("failed to format urls: %s", err)
 							}
+							receivedURLs = termMsg
 						case params.NotifyMessageLog:
 							if loggingEnabled {
 								termMsg = msg.Payload
@@ -519,6 +521,12 @@ func (s *sshServer) handleConnection(nConn net.Conn) {
 					loggingEnabled = true
 				case "nologs":
 					loggingEnabled = false
+				case "urls":
+					if len(receivedURLs) > 0 {
+						term.Write([]byte(fmt.Sprintf("%s\n", receivedURLs)))
+					} else {
+						term.Write([]byte(fmt.Sprintf("No urls received yet\n")))
+					}
 				case "quit":
 					return
 				}


### PR DESCRIPTION
This allows clients to type `nologs` or `logs` to disable or enable logging.